### PR TITLE
[MOD-2465] : Added ability to prevent rotation of scanner

### DIFF
--- a/ios/Classes/TiBarcodeModule.m
+++ b/ios/Classes/TiBarcodeModule.m
@@ -60,6 +60,7 @@
   BOOL animate = [TiUtils boolValue:[args objectForKey:@"animate"] def:YES];
   BOOL showCancel = [TiUtils boolValue:@"showCancel" properties:args def:YES];
   BOOL showRectangle = [TiUtils boolValue:@"showRectangle" properties:args def:YES];
+  BOOL preventRotation = [TiUtils boolValue:@"preventRotation" properties:args def: NO];
 
   NSMutableArray *acceptedFormats = [self metaDataObjectListFromFormtArray:[args objectForKey:@"acceptedFormats"]];
   _overlayViewProxy = [args objectForKey:@"overlay"];
@@ -80,7 +81,7 @@
     [self rememberProxy:_overlayViewProxy];
     overlayView = [self prepareOverlayWithProxy:_overlayViewProxy];
   }
-  _barcodeViewController = [[TiBarcodeViewController alloc] initWithObjectTypes:acceptedFormats delegate:self showCancel:showCancel showRectangle:showRectangle withOverlay:overlayView];
+  _barcodeViewController = [[TiBarcodeViewController alloc] initWithObjectTypes:acceptedFormats delegate:self showCancel:showCancel showRectangle:showRectangle withOverlay:overlayView preventRotation:preventRotation];
   [[_barcodeViewController scanner] setCamera:_selectedCamera ?: MTBCameraBack error:&cameraError];
 
   if (_displayedMessage != nil) {

--- a/ios/Classes/TiBarcodeViewController.h
+++ b/ios/Classes/TiBarcodeViewController.h
@@ -18,6 +18,7 @@
   @private
   TiOverlayView *_overlayView;
   BOOL _showRectangle;
+  BOOL _preventRotation;
 }
 
 - (TiOverlayView *)overlayView;
@@ -26,7 +27,8 @@
                  delegate:(id<TiOverlayViewDelegate>)delegate
                showCancel:(BOOL)shouldShowCancel
             showRectangle:(BOOL)shouldShowRectangle
-              withOverlay:(UIView *)overlay;
+              withOverlay:(UIView *)overlay
+          preventRotation:(BOOL)preventRotation;
 
 @property (nonatomic, strong) MTBBarcodeScanner *scanner;
 

--- a/ios/Classes/TiBarcodeViewController.m
+++ b/ios/Classes/TiBarcodeViewController.m
@@ -21,6 +21,7 @@
                          showCancel:(BOOL)shouldShowCancel
                       showRectangle:(BOOL)shouldShowRectangle
                         withOverlay:(UIView *)overlay
+                    preventRotation:(BOOL)preventRotation
 {
   self = [super init];
   if (self) {
@@ -34,6 +35,7 @@
                                             withOverlay:overlay];
     _showRectangle = shouldShowRectangle;
     _overlayView.delegate = delegate;
+    _preventRotation = preventRotation;
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDeviceRotation:)
@@ -82,6 +84,17 @@
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
 {
   return [[[[TiApp app] controller] topContainerController] preferredInterfaceOrientationForPresentation];
+}
+
+- (BOOL)shouldAutorotate
+{
+  [super shouldAutorotate];
+    
+  if (_preventRotation) {
+    return NO;
+  }
+    
+  return YES;
 }
 
 - (void)handleDeviceRotation:(NSNotification *)notification

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.3
+version: 2.0.4
 apiversion: 2
 architectures: armv7 i386 x86_64 arm64
 description: Lets you process 1D/2D barcodes.


### PR DESCRIPTION
https://jira.appcelerator.org/browse/MOD-2465

To prevent the scanner from auto rotating when the device is rotated you can now place preventRotation within the capture call.

barcodeScanner.capture({
              animate: false,
              overlay: overlay,
              showCancel: false,
              showRectangle: true,
              keepOpen: false,
	     preventRotation:true
          });

This is currently iOS only but I will be looking to add it to Android.