### PR TITLE
MOD-2500: feat(ios): hide status bar if root controller status bar is hidden

### DIFF
--- a/ios/Classes/TiBarcodeViewController.m
+++ b/ios/Classes/TiBarcodeViewController.m
@@ -82,6 +82,11 @@
   return [[[TiApp app] controller] preferredStatusBarStyle];
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+  return [[[TiApp app] controller] prefersStatusBarHidden];
+}
+
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation
 {
   return [[[[TiApp app] controller] topContainerController] preferredInterfaceOrientationForPresentation];


### PR DESCRIPTION
Use root viewcontroller's ```prefersStatusBarHidden``` value to show/hide status bar in Barcode scanner

JIRA: https://jira.appcelerator.org/browse/MOD-2500