### PR TITLE
Fix Android continuous scan result bitmap aspect ratio

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,7 +70,7 @@ jobs:
       run: brew install ccache
 
     - name: Retrieve ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ runner.os }}-ccache-${{ github.sha }}
@@ -91,7 +91,7 @@ jobs:
 # TODO: Grab the version so zip file name can contain it
 
     - name: Archive Android zip
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.MODULE_ID }}-android
         path: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -57,7 +57,7 @@ jobs:
       name: Build and Test
 
     - name: Archive iOS artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.MODULE_ID }}-ios
         path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Android v7.0.1
+
+## Fixes
+- Preserve the camera preview aspect ratio: the preview surface now center-crops instead of stretching to fill the screen.
+- Preserve the continuous scan result bitmap aspect ratio when drawn in the viewfinder.
+- Keep the scanner overlay within system insets, so overlay controls are not covered by the status/navigation bars on edge-to-edge devices.
+- Compute the viewfinder/decode mapping from the real window size instead of `Display.getSize()`, so the visible framing rect matches the decoded region on devices with software navigation bars.
+- Keep the preview mapping consistent when the camera driver overrides the requested preview size.
+- Extend the preview into display cutouts (notch) in landscape instead of letterboxing.
+- Avoid a potential crash in the viewfinder when the framing rect cannot be mapped to the preview yet.
+
 # v5.0.0
 
 ## BREAKING CHANGES

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,3 +4,11 @@ dependencies {
 	implementation 'com.google.zxing:android-core:3.3.0'
 	implementation 'com.google.zxing:android-integration:3.3.0'
 }
+
+// The vendored zxing-android client intentionally targets legacy (deprecated)
+// camera, preference and Wi-Fi APIs. Silence the per-usage deprecation
+// warnings so real problems remain visible in the build output.
+tasks.withType(JavaCompile).configureEach {
+	options.deprecation = false
+	options.compilerArgs << '-Xlint:-deprecation'
+}

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 7.0.0
+version: 7.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Lets you process 1D/2D barcodes.

--- a/android/platform/android/res/layout/capture.xml
+++ b/android/platform/android/res/layout/capture.xml
@@ -18,9 +18,11 @@
              android:layout_width="fill_parent"
              android:layout_height="fill_parent">
 
-  <SurfaceView android:id="@+id/preview_view"
-               android:layout_width="fill_parent"
-               android:layout_height="fill_parent"/>
+  <com.google.zxing.client.android.PreviewSurfaceView
+      android:id="@+id/preview_view"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"/>
 
   <com.google.zxing.client.android.ViewfinderView
       android:id="@+id/viewfinder_view"

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -53,6 +53,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.Surface;
 import android.view.SurfaceHolder;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -180,6 +181,14 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
                                                   View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
       window.setStatusBarColor(Color.TRANSPARENT);
       window.setNavigationBarColor(Color.TRANSPARENT);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      // Extend into display cutouts too, so the edge-to-edge preview is not letterboxed
+      // away from a notch in landscape.
+      WindowManager.LayoutParams attributes = window.getAttributes();
+      attributes.layoutInDisplayCutoutMode =
+          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+      window.setAttributes(attributes);
     }
     _instance = this;
     _layout = (FrameLayout) View.inflate(this, RHelper.getLayout("capture"), null);
@@ -340,7 +349,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     }
 
-    PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
+    SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
     SurfaceHolder surfaceHolder = surfaceView.getHolder();
     if (hasSurface) {
       // The activity was paused but not stopped, so the surface still exists. Therefore
@@ -401,7 +410,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
     beepManager.close();
     cameraManager.closeDriver();
     if (!hasSurface) {
-      PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
+      SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
       SurfaceHolder surfaceHolder = surfaceView.getHolder();
       surfaceHolder.removeCallback(this);
     }

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -37,8 +37,10 @@ import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -167,6 +169,16 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     Window window = getWindow();
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+      window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+      window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                                                  View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                                                  View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+      window.setStatusBarColor(Color.TRANSPARENT);
+      window.setNavigationBarColor(Color.TRANSPARENT);
+    }
     _instance = this;
     _layout = (FrameLayout) View.inflate(this, RHelper.getLayout("capture"), null);
 
@@ -174,6 +186,8 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     if (Intents.Scan.overlayProxy != null) {
         View overlayView = Intents.Scan.overlayProxy.getOrCreateView().getNativeView();
+        overlayView.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                                                                 FrameLayout.LayoutParams.MATCH_PARENT));
         _layout.addView(overlayView);
         overlayView.bringToFront();
     }

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -51,7 +51,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.Surface;
 import android.view.SurfaceHolder;
-import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -310,7 +309,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     }
 
-    SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
+    PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
     SurfaceHolder surfaceHolder = surfaceView.getHolder();
     if (hasSurface) {
       // The activity was paused but not stopped, so the surface still exists. Therefore
@@ -371,7 +370,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
     beepManager.close();
     cameraManager.closeDriver();
     if (!hasSurface) {
-      SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
+      PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
       SurfaceHolder surfaceHolder = surfaceView.getHolder();
       surfaceHolder.removeCallback(this);
     }
@@ -758,6 +757,11 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
     }
     try {
       cameraManager.openDriver(surfaceHolder);
+      PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
+      android.graphics.Point previewSize = cameraManager.getPreviewSizeOnScreen();
+      if (previewSize != null) {
+        surfaceView.setPreviewSize(previewSize.x, previewSize.y);
+      }
       // Creating the handler starts the preview, which can also throw a RuntimeException.
       if (handler == null) {
         handler = new CaptureActivityHandler(this, decodeFormats, decodeHints, characterSet, cameraManager);

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -56,6 +56,7 @@ import android.view.SurfaceHolder;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -126,6 +127,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
   private static final int ABOUT_ID = Menu.FIRST + 4;
 
   private FrameLayout _layout;
+  private FrameLayout _overlayContainer;
   private static CaptureActivity _instance;
 
   public boolean doKeepOpen() {
@@ -186,10 +188,25 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     if (Intents.Scan.overlayProxy != null) {
         View overlayView = Intents.Scan.overlayProxy.getOrCreateView().getNativeView();
+        _overlayContainer = new FrameLayout(this);
+        _overlayContainer.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                                                                       FrameLayout.LayoutParams.MATCH_PARENT));
+        _overlayContainer.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+          @Override
+          public WindowInsets onApplyWindowInsets(View view, WindowInsets insets) {
+            view.setPadding(insets.getSystemWindowInsetLeft(),
+                            insets.getSystemWindowInsetTop(),
+                            insets.getSystemWindowInsetRight(),
+                            insets.getSystemWindowInsetBottom());
+            return insets;
+          }
+        });
         overlayView.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
                                                                  FrameLayout.LayoutParams.MATCH_PARENT));
-        _layout.addView(overlayView);
-        overlayView.bringToFront();
+        _overlayContainer.addView(overlayView);
+        _layout.addView(_overlayContainer);
+        _overlayContainer.requestApplyInsets();
+        _overlayContainer.bringToFront();
     }
 
     hasSurface = false;
@@ -394,8 +411,10 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
   @Override
   protected void onDestroy() {
     _instance = null;
-    if (Intents.Scan.overlayProxy != null) {
-        _layout.removeView(Intents.Scan.overlayProxy.getOrCreateView().getNativeView());
+    if (_overlayContainer != null) {
+        _overlayContainer.removeAllViews();
+        _layout.removeView(_overlayContainer);
+        _overlayContainer = null;
     }
 
     inactivityTimer.shutdown();

--- a/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
+++ b/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
@@ -1,0 +1,47 @@
+package com.google.zxing.client.android;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.SurfaceView;
+
+public class PreviewSurfaceView extends SurfaceView {
+
+  private int previewHeight;
+  private int previewWidth;
+
+  public PreviewSurfaceView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public void setPreviewSize(int width, int height) {
+    previewWidth = width;
+    previewHeight = height;
+    requestLayout();
+  }
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
+    int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
+
+    if (previewWidth <= 0 || previewHeight <= 0 || parentWidth <= 0 || parentHeight <= 0) {
+      super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+      return;
+    }
+
+    float previewRatio = previewWidth / (float) previewHeight;
+    float parentRatio = parentWidth / (float) parentHeight;
+
+    int measuredWidth;
+    int measuredHeight;
+    if (parentRatio < previewRatio) {
+      measuredWidth = Math.round(parentHeight * previewRatio);
+      measuredHeight = parentHeight;
+    } else {
+      measuredWidth = parentWidth;
+      measuredHeight = Math.round(parentWidth / previewRatio);
+    }
+
+    setMeasuredDimension(measuredWidth, measuredHeight);
+  }
+}

--- a/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
+++ b/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
@@ -1,8 +1,12 @@
 package com.google.zxing.client.android;
 
 import android.content.Context;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.SurfaceView;
+
+import com.google.zxing.client.android.camera.CameraManager;
 
 public class PreviewSurfaceView extends SurfaceView {
 
@@ -29,19 +33,10 @@ public class PreviewSurfaceView extends SurfaceView {
       return;
     }
 
-    float previewRatio = previewWidth / (float) previewHeight;
-    float parentRatio = parentWidth / (float) parentHeight;
-
-    int measuredWidth;
-    int measuredHeight;
-    if (parentRatio < previewRatio) {
-      measuredWidth = Math.round(parentHeight * previewRatio);
-      measuredHeight = parentHeight;
-    } else {
-      measuredWidth = parentWidth;
-      measuredHeight = Math.round(parentWidth / previewRatio);
-    }
-
-    setMeasuredDimension(measuredWidth, measuredHeight);
+    // Reuse the exact center-crop math CameraManager uses to model the preview on screen,
+    // so the rendered preview and the decode mapping can never drift apart.
+    Rect previewRect = CameraManager.getPreviewRectOnScreen(new Point(parentWidth, parentHeight),
+                                                            new Point(previewWidth, previewHeight));
+    setMeasuredDimension(previewRect.width(), previewRect.height());
   }
 }

--- a/android/src/com/google/zxing/client/android/ViewfinderView.java
+++ b/android/src/com/google/zxing/client/android/ViewfinderView.java
@@ -100,9 +100,9 @@ public final class ViewfinderView extends View {
     }
 
     if (resultBitmap != null) {
-      // Draw the opaque result bitmap over the scanning rectangle
+      // Draw the result bitmap without distorting its camera-frame aspect ratio.
       paint.setAlpha(CURRENT_POINT_OPACITY);
-      canvas.drawBitmap(resultBitmap, null, frame, paint);
+      canvas.drawBitmap(resultBitmap, null, getResultBitmapFrame(resultBitmap, frame), paint);
     } else {
       if (showRectangle) {
         // Draw a two pixel solid black border inside the framing rect
@@ -199,6 +199,16 @@ public final class ViewfinderView extends View {
 
   public void setShowRectangle(boolean showRectangle) {
     this.showRectangle = showRectangle;
+  }
+
+  private static Rect getResultBitmapFrame(Bitmap bitmap, Rect frame) {
+    float scale = Math.min(frame.width() / (float) bitmap.getWidth(),
+                           frame.height() / (float) bitmap.getHeight());
+    int width = Math.round(bitmap.getWidth() * scale);
+    int height = Math.round(bitmap.getHeight() * scale);
+    int left = frame.left + (frame.width() - width) / 2;
+    int top = frame.top + (frame.height() - height) / 2;
+    return new Rect(left, top, left + width, top + height);
   }
 
 }

--- a/android/src/com/google/zxing/client/android/ViewfinderView.java
+++ b/android/src/com/google/zxing/client/android/ViewfinderView.java
@@ -120,38 +120,42 @@ public final class ViewfinderView extends View {
         canvas.drawRect(frame.left + 2, middle - 1, frame.right - 1, middle + 2, paint);
       }
 
+      // The framing rect may not be mappable to the preview yet (or may map to a
+      // degenerate rect) — skip drawing the result points rather than crash.
       Rect previewFrame = cameraManager.getFramingRectInPreview();
-      float scaleX = frame.width() / (float) previewFrame.width();
-      float scaleY = frame.height() / (float) previewFrame.height();
+      if (previewFrame != null) {
+        float scaleX = frame.width() / (float) previewFrame.width();
+        float scaleY = frame.height() / (float) previewFrame.height();
 
-      List<ResultPoint> currentPossible = possibleResultPoints;
-      List<ResultPoint> currentLast = lastPossibleResultPoints;
-      int frameLeft = frame.left;
-      int frameTop = frame.top;
-      if (currentPossible.isEmpty()) {
-        lastPossibleResultPoints = null;
-      } else {
-        possibleResultPoints = new ArrayList<ResultPoint>(5);
-        lastPossibleResultPoints = currentPossible;
-        paint.setAlpha(CURRENT_POINT_OPACITY);
-        paint.setColor(resultPointColor);
-        synchronized (currentPossible) {
-          for (ResultPoint point : currentPossible) {
-            canvas.drawCircle(frameLeft + (int) (point.getX() * scaleX),
-                              frameTop + (int) (point.getY() * scaleY),
-                              POINT_SIZE, paint);
+        List<ResultPoint> currentPossible = possibleResultPoints;
+        List<ResultPoint> currentLast = lastPossibleResultPoints;
+        int frameLeft = frame.left;
+        int frameTop = frame.top;
+        if (currentPossible.isEmpty()) {
+          lastPossibleResultPoints = null;
+        } else {
+          possibleResultPoints = new ArrayList<ResultPoint>(5);
+          lastPossibleResultPoints = currentPossible;
+          paint.setAlpha(CURRENT_POINT_OPACITY);
+          paint.setColor(resultPointColor);
+          synchronized (currentPossible) {
+            for (ResultPoint point : currentPossible) {
+              canvas.drawCircle(frameLeft + (int) (point.getX() * scaleX),
+                                frameTop + (int) (point.getY() * scaleY),
+                                POINT_SIZE, paint);
+            }
           }
         }
-      }
-      if (currentLast != null) {
-        paint.setAlpha(CURRENT_POINT_OPACITY / 2);
-        paint.setColor(resultPointColor);
-        synchronized (currentLast) {
-          float radius = POINT_SIZE / 2.0f;
-          for (ResultPoint point : currentLast) {
-            canvas.drawCircle(frameLeft + (int) (point.getX() * scaleX),
-                              frameTop + (int) (point.getY() * scaleY),
-                              radius, paint);
+        if (currentLast != null) {
+          paint.setAlpha(CURRENT_POINT_OPACITY / 2);
+          paint.setColor(resultPointColor);
+          synchronized (currentLast) {
+            float radius = POINT_SIZE / 2.0f;
+            for (ResultPoint point : currentLast) {
+              canvas.drawCircle(frameLeft + (int) (point.getX() * scaleX),
+                                frameTop + (int) (point.getY() * scaleY),
+                                radius, paint);
+            }
           }
         }
       }

--- a/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraConfigurationManager.java
@@ -16,6 +16,7 @@
 
 package com.google.zxing.client.android.camera;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
@@ -24,6 +25,7 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Display;
 import android.view.Surface;
+import android.view.View;
 import android.view.WindowManager;
 
 import com.google.zxing.client.android.PreferencesActivity;
@@ -108,6 +110,15 @@ public final class CameraConfigurationManager {
 
     Point theScreenResolution = new Point();
     display.getSize(theScreenResolution);
+    // The capture activity lays out edge-to-edge (see CaptureActivity.onCreate), so the
+    // preview and viewfinder span the real window rather than Display.getSize(), which
+    // excludes the navigation bar. Prefer the actual content size when it is available.
+    if (context instanceof Activity) {
+      View content = ((Activity) context).findViewById(android.R.id.content);
+      if (content != null && content.getWidth() > 0 && content.getHeight() > 0) {
+        theScreenResolution.set(content.getWidth(), content.getHeight());
+      }
+    }
     screenResolution = theScreenResolution;
     Log.d(TAG, "Screen resolution in current orientation: " + screenResolution);
     cameraResolution = CameraConfigurationUtils.findBestPreviewSizeValue(parameters, screenResolution);
@@ -115,15 +126,22 @@ public final class CameraConfigurationManager {
     bestPreviewSize = CameraConfigurationUtils.findBestPreviewSizeValue(parameters, screenResolution);
     Log.d(TAG, "Best available preview size: " + bestPreviewSize);
 
+    previewSizeOnScreen = computePreviewSizeOnScreen();
+    Log.d(TAG, "Preview size on screen: " + previewSizeOnScreen);
+  }
+
+  /**
+   * Orients {@link #bestPreviewSize} to match the screen orientation. Always returns a copy so
+   * later corrections to {@code bestPreviewSize} cannot alias the returned point.
+   */
+  private Point computePreviewSizeOnScreen() {
     boolean isScreenPortrait = screenResolution.x < screenResolution.y;
     boolean isPreviewSizePortrait = bestPreviewSize.x < bestPreviewSize.y;
 
     if (isScreenPortrait == isPreviewSizePortrait) {
-      previewSizeOnScreen = bestPreviewSize;
-    } else {
-      previewSizeOnScreen = new Point(bestPreviewSize.y, bestPreviewSize.x);
+      return new Point(bestPreviewSize.x, bestPreviewSize.y);
     }
-    Log.d(TAG, "Preview size on screen: " + previewSizeOnScreen);
+    return new Point(bestPreviewSize.y, bestPreviewSize.x);
   }
 
   void setDesiredCameraParameters(OpenCamera camera, boolean safeMode) {
@@ -181,6 +199,13 @@ public final class CameraConfigurationManager {
           ", but after setting it, preview size is " + afterSize.width + 'x' + afterSize.height);
       bestPreviewSize.x = afterSize.width;
       bestPreviewSize.y = afterSize.height;
+      // Keep every size derived from the preview size consistent with what the driver
+      // actually selected, so the surface scaling, the framing-rect mapping and the
+      // preview-frame buffer dimensions all agree.
+      cameraResolution.x = afterSize.width;
+      cameraResolution.y = afterSize.height;
+      previewSizeOnScreen = computePreviewSizeOnScreen();
+      Log.d(TAG, "Corrected preview size on screen: " + previewSizeOnScreen);
     }
   }
 

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -313,7 +313,11 @@ public final class CameraManager {
     return framingRectInPreview;
   }
 
-  private static Rect getPreviewRectOnScreen(Point screenResolution, Point previewSizeOnScreen) {
+  /**
+   * Models the center-crop rect the preview occupies on screen. {@link com.google.zxing.client.android.PreviewSurfaceView}
+   * uses the same math to size itself, so the on-screen preview and the decode mapping stay in sync.
+   */
+  public static Rect getPreviewRectOnScreen(Point screenResolution, Point previewSizeOnScreen) {
     float previewRatio = previewSizeOnScreen.x / (float) previewSizeOnScreen.y;
     float screenRatio = screenResolution.x / (float) screenResolution.y;
 
@@ -365,7 +369,8 @@ public final class CameraManager {
   }
 
   public synchronized Point getPreviewSizeOnScreen() {
-    return configManager.getPreviewSizeOnScreen();
+    Point previewSizeOnScreen = configManager.getPreviewSizeOnScreen();
+    return previewSizeOnScreen == null ? null : new Point(previewSizeOnScreen);
   }
 
   

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -320,6 +320,10 @@ public final class CameraManager {
     return framingRectInPreview;
   }
 
+  public synchronized Point getPreviewSizeOnScreen() {
+    return configManager.getPreviewSizeOnScreen();
+  }
+
   
   /**
    * Allows third party apps to specify the camera ID, rather than determine

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -296,28 +296,72 @@ public final class CameraManager {
       if (framingRect == null) {
         return null;
       }
-      Rect rect = new Rect(framingRect);
-      Point cameraResolution = configManager.getCameraResolution();
+      Point previewSizeOnScreen = configManager.getPreviewSizeOnScreen();
       Point screenResolution = configManager.getScreenResolution();
-      if (cameraResolution == null || screenResolution == null) {
+      if (previewSizeOnScreen == null || screenResolution == null) {
         // Called early, before init even finished
         return null;
       }
-      if(screenResolution.x < screenResolution.y){
-          rect.left = rect.left * cameraResolution.y / screenResolution.x;
-          rect.right = rect.right * cameraResolution.y / screenResolution.x;
-          rect.top = rect.top * cameraResolution.x / screenResolution.y;
-          rect.bottom = rect.bottom * cameraResolution.x / screenResolution.y;
-      } else {
-          // landscape
-          rect.left = rect.left * cameraResolution.x / screenResolution.x;
-          rect.right = rect.right * cameraResolution.x / screenResolution.x;
-          rect.top = rect.top * cameraResolution.y / screenResolution.y;
-          rect.bottom = rect.bottom * cameraResolution.y / screenResolution.y;
+
+      Rect previewRectOnScreen = getPreviewRectOnScreen(screenResolution, previewSizeOnScreen);
+      Rect rect = mapScreenRectToPreview(framingRect, previewRectOnScreen, previewSizeOnScreen);
+      if (rect.width() <= 0 || rect.height() <= 0) {
+        return null;
       }
       framingRectInPreview = rect;
     }
     return framingRectInPreview;
+  }
+
+  private static Rect getPreviewRectOnScreen(Point screenResolution, Point previewSizeOnScreen) {
+    float previewRatio = previewSizeOnScreen.x / (float) previewSizeOnScreen.y;
+    float screenRatio = screenResolution.x / (float) screenResolution.y;
+
+    int previewWidth;
+    int previewHeight;
+    if (screenRatio < previewRatio) {
+      previewWidth = Math.round(screenResolution.y * previewRatio);
+      previewHeight = screenResolution.y;
+    } else {
+      previewWidth = screenResolution.x;
+      previewHeight = Math.round(screenResolution.x / previewRatio);
+    }
+
+    int left = (screenResolution.x - previewWidth) / 2;
+    int top = (screenResolution.y - previewHeight) / 2;
+    return new Rect(left, top, left + previewWidth, top + previewHeight);
+  }
+
+  private static Rect mapScreenRectToPreview(Rect screenRect,
+                                             Rect previewRectOnScreen,
+                                             Point previewSizeOnScreen) {
+    float scaleX = previewSizeOnScreen.x / (float) previewRectOnScreen.width();
+    float scaleY = previewSizeOnScreen.y / (float) previewRectOnScreen.height();
+
+    int left = clamp((int) Math.floor((screenRect.left - previewRectOnScreen.left) * scaleX),
+                     0,
+                     previewSizeOnScreen.x);
+    int right = clamp((int) Math.ceil((screenRect.right - previewRectOnScreen.left) * scaleX),
+                      0,
+                      previewSizeOnScreen.x);
+    int top = clamp((int) Math.floor((screenRect.top - previewRectOnScreen.top) * scaleY),
+                    0,
+                    previewSizeOnScreen.y);
+    int bottom = clamp((int) Math.ceil((screenRect.bottom - previewRectOnScreen.top) * scaleY),
+                       0,
+                       previewSizeOnScreen.y);
+
+    return new Rect(left, top, right, bottom);
+  }
+
+  private static int clamp(int value, int min, int max) {
+    if (value < min) {
+      return min;
+    }
+    if (value > max) {
+      return max;
+    }
+    return value;
   }
 
   public synchronized Point getPreviewSizeOnScreen() {


### PR DESCRIPTION
## What changed

Android continuous scan mode could show the captured result image stretched after a successful scan.

The camera preview already preserves aspect ratio with a centered crop, but the scan crop still mapped the viewfinder frame against the full screen with separate X/Y scaling. This updates the frame-to-preview mapping so `PlanarYUVLuminanceSource` uses the same centered preview bounds that the user sees on screen.

This also changes the temporary result bitmap drawing in `ViewfinderView`. Instead of stretching the bitmap to fill the frame, it now draws it centered with uniform scaling. Square QR captures stay square.

The PR also updates deprecated GitHub Actions versions used by the Android and iOS workflows. GitHub now rejects `actions/cache@v2` and `actions/upload-artifact@v2` before the job can run.

## Follow-up hardening (after self-review)

An adversarial review of the branch surfaced a few edge cases, addressed in follow-up commits:

- **Real window size as the geometry basis** — the capture activity lays out edge-to-edge, but the framing rect / preview mapping still used `Display.getSize()` (excludes the navigation bar). On devices with a software nav bar the visible viewfinder and the decoded region disagreed. The mapping now prefers the activity's real content size.
- **Driver-corrected preview sizes** — when the camera driver overrides the requested preview size, `cameraResolution` and `previewSizeOnScreen` now stay consistent with it (previously they went stale, which could silently break decoding).
- **Display cutouts** — the window now extends into the notch (`LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`) so landscape previews are not letterboxed.
- **NPE guard** — `ViewfinderView.onDraw` no longer crashes if the framing rect cannot be mapped to the preview yet.
- **Single source of truth** — `PreviewSurfaceView` now reuses `CameraManager`'s center-crop math instead of duplicating it.
- Module bumped to **7.0.1** with a CHANGELOG entry.
- Build hygiene: disabled the per-usage deprecation lint for the vendored zxing sources (they intentionally target legacy camera/Wi-Fi APIs and produced 100+ warnings on every build, hiding real problems).

## Tested

- Built the Android module with `ti build -p android --build-only` (Titanium SDK 13.3.0.GA) — green, packages `ti.barcode-android-7.0.1.zip`.
- Follow-up hardening commits verified on a real device (OnePlus CPH2639): continuous scan (`keepOpen: true`) with a custom thin framing rect (300×50 dp) decodes only the barcode under the frame, result bitmap keeps its aspect ratio, and the overlay stays within system insets.
- Tested on a real Android device with the example app:
  `example/app.js`
- Verified `Scan the Code (continuous)` with `keepOpen: true`.
- Confirmed the captured result image is no longer distorted.
- Confirmed the initial camera preview aspect ratio fix is still intact.

